### PR TITLE
Fix: Handle stories fetch storybook v8

### DIFF
--- a/packages/browser/src/handle-stories-fetch.js
+++ b/packages/browser/src/handle-stories-fetch.js
@@ -1,0 +1,39 @@
+/**
+ * Storybook V8 initilization includes a fetch call to the index.json file. The index.json file includes a json object
+ * with all the stories from the storybook build.
+ *
+ * Since Loki is accessing the storybook build using file-based urls (file://tmp/storybook-static/iframe.html),
+ * Chromium will not be able to fetch the index.json file. (Fetch calls are blocked for security reasons.)
+ *
+ * This function handles the fetch call to the index.json file and returns the content of the file based on the
+ * storiesJson parameter.
+ *
+ * If this function doesn't do it, we would get 'failed to fetch' errors instead of the stories being rendered.
+ *
+ * @param {Window} window - The window object.
+ * @param {string} storiesJson - The json object with all the stories from the storybook build.
+ */
+const handleStoriesFetch = function (window, storiesJson) {
+  const originalFetch = window.fetch;
+
+  const mockedFetch = (url, options) => {
+    if (url.endsWith('index.json')) {
+      return Promise.resolve(
+        // eslint-disable-next-line no-undef
+        new Response(storiesJson, {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    }
+
+    return originalFetch(url, options);
+  };
+
+  if (window && window.fetch) {
+    // eslint-disable-next-line no-param-reassign
+    window.fetch = mockedFetch;
+  }
+};
+
+module.exports = handleStoriesFetch;

--- a/packages/browser/src/index.js
+++ b/packages/browser/src/index.js
@@ -6,6 +6,7 @@ const disableInputCaret = require('./disable-input-caret');
 const disablePointerEvents = require('./disable-pointer-events');
 const getSelectorBoxSize = require('./get-selector-box-size');
 const getStorybookError = require('./get-storybook-error');
+const handleStoriesFetch = require('./handle-stories-fetch');
 const getStories = require('./get-stories');
 const populateLokiHelpers = require('./populate-loki-helpers');
 const setLokiIsRunning = require('./set-loki-is-running');
@@ -20,6 +21,7 @@ module.exports = {
   disablePointerEvents,
   getSelectorBoxSize,
   getStorybookError,
+  handleStoriesFetch,
   getStories,
   populateLokiHelpers,
   setLokiIsRunning,

--- a/packages/core/src/get-stories-from-index.js
+++ b/packages/core/src/get-stories-from-index.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Storybook V8 builds includes an index.json file that contains all the stories for the project.
+ * This function reads the index.json file and returns the content of the file.
+ *
+ * @param {string} baseUrl - The base url of the storybook build.
+ * @returns {string} - The content of the index.json file.
+ */
+function getStoriesFromIndex(baseUrl) {
+  const absoluteUrl = baseUrl.startsWith('file:')
+    ? baseUrl.replace('file:', '')
+    : baseUrl;
+
+  const indexJsonContent = fs.readFileSync(
+    path.join(absoluteUrl, 'index.json'),
+    'utf8'
+  );
+
+  return JSON.stringify(JSON.parse(indexJsonContent));
+}
+
+module.exports = { getStoriesFromIndex };

--- a/packages/core/src/get-stories-from-index.js
+++ b/packages/core/src/get-stories-from-index.js
@@ -12,11 +12,15 @@ function getStoriesFromIndex(baseUrl) {
   const absoluteUrl = baseUrl.startsWith('file:')
     ? baseUrl.replace('file:', '')
     : baseUrl;
+  const indexJsonPath = path.join(absoluteUrl, 'index.json');
 
-  const indexJsonContent = fs.readFileSync(
-    path.join(absoluteUrl, 'index.json'),
-    'utf8'
-  );
+  // If no index.json file is found, return an empty string.
+  // This is only required for a storybook V7 build.
+  if (!fs.existsSync(indexJsonPath)) {
+    return '';
+  }
+
+  const indexJsonContent = fs.readFileSync(indexJsonPath, 'utf8');
 
   return JSON.stringify(JSON.parse(indexJsonContent));
 }

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -4,12 +4,14 @@ const dependencyDetection = require('./dependency-detection');
 const getAbsoluteURL = require('./get-absolute-url');
 const { getLocalIPAddress } = require('./get-local-ip-address');
 const { createStaticServer } = require('./create-static-server');
+const { getStoriesFromIndex } = require('./get-stories-from-index');
 
 module.exports = Object.assign(
   {
     getAbsoluteURL,
     getLocalIPAddress,
     createStaticServer,
+    getStoriesFromIndex,
   },
   errors,
   failureHandling,


### PR DESCRIPTION
We are currently migrating our Storybook version from 7 to 8. We've noticed that:

A `fetch` call in Storybook V8 breaks loki's aws-lambda-renderer.

Storybook V8 initialization calls `getStoryIndexFromServer` [function](https://github.com/storybookjs/storybook/blob/4a5d3f5a9f497d2a30e5394c6bd4868cd2f87a21/code/core/src/preview-api/modules/preview-web/Preview.tsx#L193) which tries to load a file called `index.json` (A json with all the stories loaded in the storybook build) using `fetch`. This breaks Loki's aws-lambda-renderer because it depends on file-based `file://TMP_FOLDER/iframe.html?id=STORY_ID` access. (File-based access doesn't support `fetch`).

This PR fixes the `failed to fetch` error by handling the fetch call without actually fetching. 

1. Loki's aws-lambda-renderer script (running on lambda) does a `readFileSync` to load the content of `index.json` file.
2. Loki's aws-lambda-renderer script injects a script into the chrome tab running Storybook to overwrite the `fetch` function implementation as follows:

* If fetch is called with `index.json`, it returns the stories list. 
* If fetch is called with any other input, it invokes the original fetch. 